### PR TITLE
Add build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nob
 nob.old
 build/
+.zig-cache
+zig-out/bin

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    const module = b.addModule("main", .{
+        .target = target,
+        .link_libc = true,
+    });
+
+    module.addCSourceFiles(.{
+        .files = &.{
+            "src/posix6502.c",
+            "src/fake6502.c",
+        },
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "hello",
+        .root_module = module,
+    });
+
+    b.installArtifact(exe);
+}


### PR DESCRIPTION
Add zig as an optional build system.

benefits over nob: 

* allows compiling the project in a single command 
```
zig build
```
instead of two
```
cc -o nob nob.c
./nob
```
* Increased cold compile time `0.8s -> 19.4s` which allows rethinking life decisions.